### PR TITLE
feat(local-env-config): adds a config option to use local env vars instead of consul for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # serverless-service-config-plugin
 Serverless Plugin to retrieve config and secrets for services in Consul and Vault
+
+Usage:
+
+```yaml
+custom:
+    service_config_plugin:
+        consulAddr: https://consul.corp.domain
+        consulPrefix: app_config_vars/
+        vaultAddr: https://vault.corp.domain
+        kmsKeyId:
+            proof: 87y3gh4ei982yh3jeiou2yh2j3eorue1
+            prod: 2349u23iuh2j3oiuh2j3oi2j3eo
+        # Array of stages that should use environment variables instead
+        # of consul to fulfill service config variables
+        # the segment of the path after the last "/" will be looked for in process.envs
+        localEnvVarStages:
+            - local
+            - test
+```

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,14 @@ class ServerlessServiceConfig {
 
   useLocalEnvVars() {
     const { service_config_plugin } = this.serverless.service.custom;
+    const { provider } = this.serverless.service;
 
-    if (service_config_plugin.useLocalEnvVars) {
-      this.serverlessLog('Service config will use local environment variables: `custom.service_config_plugin.useLocalEnvVars` evaluates to true');
+    const stage = (this.options && this.options.stage) || (provider && provider.stage);
+
+    const { localEnvVarStages } = service_config_plugin;
+
+    if (localEnvVarStages && localEnvVarStages.includes(stage)) {
+      this.serverlessLog(`Service config will use local environment variables: 'custom.service_config_plugin.localEnvVarStages' includes current stage '${stage}'`);
       return true;
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -30,12 +30,52 @@ test('serviceConfig', (t) => {
             consulPrefix: 'prefix'
           }
         }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+        }
       }
     });
 
     const value = await service.getServiceConfig('serviceConfig:config_path/key');
 
     assert.equal(value, 'a sample value');
+  });
+
+  t.test('should use process.env to get config when `useLocalEnvVars` is true', async (assert) => {
+    assert.plan(1);
+
+    consulStub.reset();
+
+    process.env.key = 'an env var value';
+
+    consulStub
+      .withArgs('http://consul/v1/kv/prefix/config_path/key')
+      .resolves('a sample value');
+
+    const service = new ServerlessServiceConfig({
+      service: {
+        custom: {
+          service_config_plugin: {
+            consulAddr: 'http://consul',
+            consulPrefix: 'prefix',
+            useLocalEnvVars: true,
+          }
+        }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+        }
+      }
+    });
+
+    const value = await service.getServiceConfig('serviceConfig:config_path/key');
+
+    assert.equal(value, 'an env var value');
   });
 });
 
@@ -58,6 +98,12 @@ test('secretConfig', (t) => {
             vaultAddr: 'http://vault_server',
             kmsKeyId,
           }
+        }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
         }
       }
     };
@@ -96,6 +142,12 @@ test('secretConfig', (t) => {
             kmsKeyConsulPath,
           }
         }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+        }
       }
     };
 
@@ -132,6 +184,12 @@ test('secretConfig', (t) => {
         custom: {
           service_config_plugin: {}
         }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+        }
       }
     });
 
@@ -157,6 +215,12 @@ test('secretConfig', (t) => {
             }
           }
         }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+        }
       }
     });
 
@@ -165,5 +229,53 @@ test('secretConfig', (t) => {
     } catch (e) {
       assert.match(e.message, /^KMS Key Id missing/);
     }
+  });
+
+  t.test('should use process.env to get secret config when `useLocalEnvVars` is true', async (assert) => {
+    assert.plan(1);
+
+    process.env.key = 'an env var value';
+
+    const fakeKms = {};
+    const kmsKeyId = {
+      stage: 'kmsKeyId'
+    };
+    const slsConfig = {
+      service: {
+        provider: {
+          stage: 'stage'
+        },
+        custom: {
+          service_config_plugin: {
+            consulAddr: 'http://consul',
+            vaultAddr: 'http://vault_server',
+            kmsKeyId,
+            useLocalEnvVars: true,
+          }
+        }
+      },
+      cli: {
+        log(message) {
+          // eslint-disable-next-line no-console
+          console.log(message);
+        }
+      }
+    };
+
+    vault2kmsStub.reset();
+    vault2kmsStub
+      .withArgs('http://consul/v1/kv/vault/my_secret/secret', 'http://vault_server/v1/', fakeKms, 'kmsKeyId')
+      .resolves('a base64 encrypted secret');
+
+    kmsConfigStub.reset();
+    kmsConfigStub
+      .withArgs(slsConfig)
+      .returns(fakeKms);
+
+    const service = new ServerlessServiceConfig(slsConfig);
+
+    const value = await service.getServiceConfig('secretConfig:config_path/key');
+
+    assert.equal(value, 'an env var value');
   });
 });


### PR DESCRIPTION
this change allows you to resolve serviceConfig paths with locally defined environment variables so that consul authentication is not needed for local development and testing