### PR TITLE
v3 serverless framework upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # serverless-service-config-plugin
 Serverless Plugin to retrieve config and secrets for services in Consul and Vault
 
-All secrets from Vault are encrypted with a KMS key. This to prevent the secrets leaking into the Cloudformation templates, which end up being readable in the AWS Console. This means they must be decrypted in code when being retrieved from environment.
+All secrets from Vault are encrypted with a KMS key by the plugin. This to prevent secrets leaking into the Cloudformation templates, which end up being readable in the AWS Console. This means they must be decrypted in code using KMS after being retrieved from environment.
 
 ## Usage:
 
@@ -37,18 +37,18 @@ custom:
 ```
 
 ## Upgrade to plugin 1.0 / slsv3:
-Serverless v3 contained some [https://www.serverless.com/framework/docs/guides/upgrading-v3](major changes) to how custom variables and parameters are used, notably that arbitrary CLI parameters are no longer permitted. WealthWizards used these heavily. Thankfully they also added in params as a good alternative. When migrating a project to serverless framework v3 / v1.0 of this plugin, you will need to do the following:
+Serverless v3 contained some [https://www.serverless.com/framework/docs/guides/upgrading-v3](major changes) to how custom variables and parameters are used, notably that arbitrary CLI parameters are no longer permitted. WealthWizards used these heavily. Thankfully they also added in params as a good alternative. When migrating a project to serverless framework v3 / v1.0 of this plugin, you will need be mindful of the following:
 
-- Any use of custom variables dependant on `opt` interpolation will no longer work, e.g.
-```
+- Any use of custom variables dependant on `opt` interpolation and custom cli vars will no longer work, e.g.
+```yaml
   tenant: ${opt:tenant, 'tenant'}
 ```
 This should be replaced by the use of params:
-```
+```yaml
   tenant: ${param:tenant}
 ```
-Params can be specified on the CLI, and helpfully you can also provide per stage params in your yml alongisde a default. As a simple example:
-```
+Params can be specified on the CLI, and helpfully you can also provide per stage params in your yml alongside a default. As a simple example:
+```yaml
 params:
   default:
     accountId: xxxx
@@ -58,10 +58,8 @@ params:
     accountName: prod
 ```
 
-- Stage is the source of truth for your environment. Bin off any unnecessary additional variables such as `{opt.environment}`.
+- Stage is the source of truth for your environment. Remove any redundant variables such as `{opt.environment}`, these should no longer be required when using `params`. This makes deploying personal stacks and feature branches simpler too, as `params` allows for having default parameter sets within YML (see above).
 
-_Aside_: From what I can glean, this does mean that compiling a single artifact set is no longer possible, as the stage and its parameters are required at _package time_, as they are then baked into the Cloudformation template.
+_Aside_: From what I can glean, this does mean that compiling a single artifact of code + CF template is no longer possible, as the stage and its parameters are required at _package time_. These are then baked into the Cloudformation template.
 
-This makes deploying personal stacks and feature branches simpler too, as `params` allows having some default development config.
-
-- Changed interface and usage to be more direct. `serviceConfig` and `secretConfig` have been replaced by `consul` and `vault` respectively. The existing pattern of using `secretConfig` pointing to a Consul path, whose value contains a Vault path, has been replaced with a direct vault path.
+- Bonus breakage: Changed interface and usage to be more direct. `serviceConfig` and `secretConfig` have been replaced by `consul` and `vault` respectively. The existing pattern of using `secretConfig` pointing to a Consul path, whose value contains a Vault path, has been replaced with a direct vault path.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # serverless-service-config-plugin
 Serverless Plugin to retrieve config and secrets for services in Consul and Vault
 
-Usage:
+All secrets from Vault are encrypted with a KMS key. This to prevent the secrets leaking into the Cloudformation templates, which end up being readable in the AWS Console. This means they must be decrypted in code when being retrieved from environment.
+
+## Usage:
 
 ```yaml
 custom:
+    myVaultVar: ${vault:/secrets/mysecret} # takes secret at /secrets/mysecret from Vault, KMS encrypts it, and makes it available as a custom variable
+    myConsulVar: ${consul:/app.json/green/myconfig} # takes kv item from path in Consul and makes it available as a custom variable 
     service_config_plugin:
         consulAddr: https://consul.corp.domain
         consulPrefix: app_config_vars/
@@ -18,4 +22,46 @@ custom:
         localEnvVarStages:
             - local
             - test
+    functions:
+        calculate:
+            handler: src/handlers.calculate
+            environment:
+                # BEWARE: This will require KMS decryption to be useable
+                MY_SECRET_VAR: ${self:custom.myVaultVar}
+                # This will be plaintext
+                MY_CONFIG_VAR: ${self:custom.myConsulVar}
+            events:
+                - http:
+                path: /v1/calculate
+                method: post
 ```
+
+## Upgrade to plugin 1.0 / slsv3:
+Serverless v3 contained some [https://www.serverless.com/framework/docs/guides/upgrading-v3](major changes) to how custom variables and parameters are used, notably that arbitrary CLI parameters are no longer permitted. WealthWizards used these heavily. Thankfully they also added in params as a good alternative. When migrating a project to serverless framework v3 / v1.0 of this plugin, you will need to do the following:
+
+- Any use of custom variables dependant on `opt` interpolation will no longer work, e.g.
+```
+  tenant: ${opt:tenant, 'tenant'}
+```
+This should be replaced by the use of params:
+```
+  tenant: ${param:tenant}
+```
+Params can be specified on the CLI, and helpfully you can also provide per stage params in your yml alongisde a default. As a simple example:
+```
+params:
+  default:
+    accountId: xxxx
+    accountName: proof
+  red:
+    accountId: yyyy
+    accountName: prod
+```
+
+- Stage is the source of truth for your environment. Bin off any unnecessary additional variables such as `{opt.environment}`.
+
+_Aside_: From what I can glean, this does mean that compiling a single artifact set is no longer possible, as the stage and its parameters are required at _package time_, as they are then baked into the Cloudformation template.
+
+This makes deploying personal stacks and feature branches simpler too, as `params` allows having some default development config.
+
+- Changed interface and usage to be more direct. `serviceConfig` and `secretConfig` have been replaced by `consul` and `vault` respectively. The existing pattern of using `secretConfig` pointing to a Consul path, whose value contains a Vault path, has been replaced with a direct vault path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-service-config-plugin",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Retrieve service configs and secrets from Consul and Vault",
   "main": "src/index.js",
   "scripts": {
@@ -14,7 +14,6 @@
   "license": "MIT",
   "dependencies": {
     "aws-sdk": "^2.1127.0",
-    "eslint-config-airbnb-base": "^15.0.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9"
   },
@@ -22,6 +21,7 @@
     "@wealthizardsengineering/tap-summary": "git+https://github.com/WealthWizardsEngineering/tap-summary.git",
     "escope": "^3.6.0",
     "eslint": "^8.2.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.2",
     "proxyquire": "^2.1.3",
     "sinon": "^9.2.4",

--- a/src/consul.js
+++ b/src/consul.js
@@ -16,14 +16,18 @@ async function get(url, fallback = null) {
     });
 
     if (consulData && consulData[0] && consulData[0].Value) {
-      return Buffer.from(consulData[0].Value, 'base64').toString();
+      return {
+        value: Buffer.from(consulData[0].Value, 'base64').toString()
+      };
     }
   } catch (e) {
     if (e.statusCode !== 404) throw e;
   }
 
   if (fallback) {
-    return fallback;
+    return {
+      value: fallback
+    };
   }
   throw new Error(`Missing value in Consul at ${url}`);
 }

--- a/src/consul.test.js
+++ b/src/consul.test.js
@@ -27,7 +27,7 @@ test('should retrieve data from consul', async (assert) => {
 
   const consulValue = await consul.get('http://consul/kv/myKey');
 
-  assert.equal(consulValue, 'this is my config value');
+  assert.equal(consulValue.value, 'this is my config value');
 });
 
 test('should fail if no value is found', async (assert) => {
@@ -68,7 +68,7 @@ test('should return fallback if defined and key not present in consul', async (a
 
   const consulValue = await consul.get('http://consul/kv/myKey', 'fallback');
 
-  assert.equal(consulValue, 'fallback');
+  assert.equal(consulValue.value, 'fallback');
 });
 
 test('after', (t) => {

--- a/src/index.js
+++ b/src/index.js
@@ -68,10 +68,9 @@ class ServerlessServiceConfig {
 
     const { kmsKeyId = {}, kmsKeyConsulPath } = config;
     let kmsKeyIdValue;
-    console.log(kmsKeyId, kmsKeyConsulPath)
     if (kmsKeyConsulPath && typeof kmsKeyConsulPath === 'string') {
       kmsKeyIdValue = await this.getServiceConfig({ address: kmsKeyConsulPath });
-      kmsKeyIdValue = kmsKeyIdValue.value
+      kmsKeyIdValue = kmsKeyIdValue.value;
     } else if (kmsKeyId[stage]) {
       kmsKeyIdValue = kmsKeyId[stage];
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,12 @@ class ServerlessServiceConfig {
   static getEnvVar(path) {
     const envVar = path.substring(path.lastIndexOf('/') + 1);
 
-    return {value: process.env[envVar]};
+    return { value: process.env[envVar] };
   }
 
   async getServiceConfig(param) {
     // console.log(param)
-    const { path, fallback } = getGroups( param.address);
+    const { path, fallback } = getGroups(param.address);
     // console.log(path)
     // const path = param.address
     if (this.useLocalEnvVars()) {
@@ -54,10 +54,10 @@ class ServerlessServiceConfig {
     const { service_config_plugin } = this.serverless.service.custom;
     const config = pluginConfig.load(service_config_plugin);
 
-    return consul.get(`${config.consulUrl()}${path}`, fallback)
+    return consul.get(`${config.consulUrl()}${path}`, fallback);
   }
 
-  async getSecretConfig(param ) {
+  async getSecretConfig(param) {
     const { path, fallback } = getGroups(param.address);
 
     if (this.useLocalEnvVars()) {
@@ -72,7 +72,7 @@ class ServerlessServiceConfig {
     const { kmsKeyId = {}, kmsKeyConsulPath } = config;
     let kmsKeyIdValue;
     if (kmsKeyConsulPath && typeof kmsKeyConsulPath === 'string') {
-      kmsKeyIdValue = await this.getServiceConfig({address: kmsKeyConsulPath});
+      kmsKeyIdValue = await this.getServiceConfig({ address: kmsKeyConsulPath });
     } else if (kmsKeyId[stage]) {
       kmsKeyIdValue = kmsKeyId[stage];
     } else {
@@ -87,7 +87,7 @@ class ServerlessServiceConfig {
       kmsConfig.load(this.serverless),
       kmsKeyIdValue,
       fallback
-    )
+    );
   }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -396,7 +396,7 @@ test('vault', (t) => {
     kmsConfigStub.withArgs(slsConfig).returns(fakeKms);
 
     const getServiceConfigStub = sinon.stub();
-    getServiceConfigStub.withArgs({ address: 'path/to/key_id' }).returns({'value': 'kmsKeyId'});
+    getServiceConfigStub.withArgs({ address: 'path/to/key_id' }).returns({ value: 'kmsKeyId' });
 
     const service = new ServerlessServiceConfig(slsConfig);
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -179,7 +179,7 @@ test('useLocalEnvVars', (t) => {
   );
 });
 
-test('serviceConfig', (t) => {
+test('consul', (t) => {
   t.test('should call consul with fallback', async (assert) => {
     assert.plan(1);
     const service = new ServerlessServiceConfig({
@@ -267,7 +267,7 @@ test('serviceConfig', (t) => {
   });
 });
 
-test('secretConfig', (t) => {
+test('vault', (t) => {
   t.test('should query vault with fallback', async (assert) => {
     assert.plan(1);
 
@@ -299,7 +299,7 @@ test('secretConfig', (t) => {
     await service.getSecretConfig({ address: 'vault/my_secret/secret, "fallback"' });
     assert.true(
       vault2kmsStub.calledWith(
-        'http://consul/v1/kv/vault/my_secret/secret',
+        'vault/my_secret/secret',
         'http://vault_server/v1/',
         undefined,
         'kmsKeyId',
@@ -339,7 +339,7 @@ test('secretConfig', (t) => {
     vault2kmsStub.reset();
     vault2kmsStub
       .withArgs(
-        'http://consul/v1/kv/vault/my_secret/secret',
+        'vault/my_secret/secret',
         'http://vault_server/v1/',
         fakeKms,
         'kmsKeyId'
@@ -385,7 +385,7 @@ test('secretConfig', (t) => {
     vault2kmsStub.reset();
     vault2kmsStub
       .withArgs(
-        'http://consul/v1/kv/vault/my_secret/secret',
+        'vault/my_secret/secret',
         'http://vault_server/v1/',
         fakeKms,
         'kmsKeyId'
@@ -396,7 +396,7 @@ test('secretConfig', (t) => {
     kmsConfigStub.withArgs(slsConfig).returns(fakeKms);
 
     const getServiceConfigStub = sinon.stub();
-    getServiceConfigStub.withArgs({ address: 'path/to/key_id' }).returns('kmsKeyId');
+    getServiceConfigStub.withArgs({ address: 'path/to/key_id' }).returns({'value': 'kmsKeyId'});
 
     const service = new ServerlessServiceConfig(slsConfig);
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -199,7 +199,7 @@ test('serviceConfig', (t) => {
       }
     });
 
-    await service.getServiceConfig({address: 'config_path/key, "fallback"'});
+    await service.getServiceConfig({ address: 'config_path/key, "fallback"' });
     assert.true(consulSpy.calledWith('http://consul/v1/kv/prefix/config_path/key', '"fallback"'));
   });
 
@@ -208,7 +208,7 @@ test('serviceConfig', (t) => {
 
     consulStub.reset();
 
-    consulStub.withArgs('http://consul/v1/kv/prefix/config_path/key').resolves({value: 'a sample value'});
+    consulStub.withArgs('http://consul/v1/kv/prefix/config_path/key').resolves({ value: 'a sample value' });
 
     const service = new ServerlessServiceConfig({
       service: {
@@ -227,7 +227,7 @@ test('serviceConfig', (t) => {
       }
     });
 
-    const value = await service.getServiceConfig({address: 'config_path/key'});
+    const value = await service.getServiceConfig({ address: 'config_path/key' });
     assert.equal(value.value, 'a sample value');
   });
 
@@ -261,7 +261,7 @@ test('serviceConfig', (t) => {
       }
     });
 
-    const value = await service.getServiceConfig({address: 'config_path/key'});
+    const value = await service.getServiceConfig({ address: 'config_path/key' });
 
     assert.equal(value.value, 'an env var value');
   });
@@ -296,7 +296,7 @@ test('secretConfig', (t) => {
     };
 
     const service = new ServerlessServiceConfig(slsConfig);
-    await service.getSecretConfig({address: 'vault/my_secret/secret, "fallback"'});
+    await service.getSecretConfig({ address: 'vault/my_secret/secret, "fallback"' });
     assert.true(
       vault2kmsStub.calledWith(
         'http://consul/v1/kv/vault/my_secret/secret',
@@ -344,14 +344,14 @@ test('secretConfig', (t) => {
         fakeKms,
         'kmsKeyId'
       )
-      .resolves({'value': 'a base64 encrypted secret'});
+      .resolves({ value: 'a base64 encrypted secret' });
 
     kmsConfigStub.reset();
     kmsConfigStub.withArgs(slsConfig).returns(fakeKms);
 
     const service = new ServerlessServiceConfig(slsConfig);
 
-    const value = await service.getSecretConfig({address: 'vault/my_secret/secret'});
+    const value = await service.getSecretConfig({ address: 'vault/my_secret/secret' });
 
     assert.equal(value.value, 'a base64 encrypted secret');
   });
@@ -390,19 +390,19 @@ test('secretConfig', (t) => {
         fakeKms,
         'kmsKeyId'
       )
-      .resolves({'value': 'a base64 encrypted secret'});
+      .resolves({ value: 'a base64 encrypted secret' });
 
     kmsConfigStub.reset();
     kmsConfigStub.withArgs(slsConfig).returns(fakeKms);
 
     const getServiceConfigStub = sinon.stub();
-    getServiceConfigStub.withArgs({address: 'path/to/key_id'}).returns('kmsKeyId');
+    getServiceConfigStub.withArgs({ address: 'path/to/key_id' }).returns('kmsKeyId');
 
     const service = new ServerlessServiceConfig(slsConfig);
 
     service.getServiceConfig = getServiceConfigStub;
 
-    const value = await service.getSecretConfig({address: 'vault/my_secret/secret'});
+    const value = await service.getSecretConfig({ address: 'vault/my_secret/secret' });
 
     assert.equal(value.value, 'a base64 encrypted secret');
   });
@@ -428,7 +428,7 @@ test('secretConfig', (t) => {
     });
 
     try {
-      await service.getSecretConfig({address: 'vault/my_secret/secret'});
+      await service.getSecretConfig({ address: 'vault/my_secret/secret' });
     } catch (e) {
       assert.match(e.message, /^KMS Key Id missing/);
     }
@@ -459,7 +459,7 @@ test('secretConfig', (t) => {
     });
 
     try {
-      await service.getSecretConfig({address: 'vault/my_secret/secret'});
+      await service.getSecretConfig({ address: 'vault/my_secret/secret' });
     } catch (e) {
       assert.match(e.message, /^KMS Key Id missing/);
     }
@@ -514,7 +514,7 @@ test('secretConfig', (t) => {
 
       const service = new ServerlessServiceConfig(slsConfig);
 
-      const value = await service.getServiceConfig({address: 'config_path/key'});
+      const value = await service.getServiceConfig({ address: 'config_path/key' });
 
       assert.equal(value.value, 'an env var value');
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -199,7 +199,7 @@ test('serviceConfig', (t) => {
       }
     });
 
-    await service.getServiceConfig('serviceConfig:config_path/key, "fallback"');
+    await service.getServiceConfig({address: 'config_path/key, "fallback"'});
     assert.true(consulSpy.calledWith('http://consul/v1/kv/prefix/config_path/key', '"fallback"'));
   });
 
@@ -208,7 +208,7 @@ test('serviceConfig', (t) => {
 
     consulStub.reset();
 
-    consulStub.withArgs('http://consul/v1/kv/prefix/config_path/key').resolves('a sample value');
+    consulStub.withArgs('http://consul/v1/kv/prefix/config_path/key').resolves({value: 'a sample value'});
 
     const service = new ServerlessServiceConfig({
       service: {
@@ -227,9 +227,8 @@ test('serviceConfig', (t) => {
       }
     });
 
-    const value = await service.getServiceConfig('serviceConfig:config_path/key');
-
-    assert.equal(value, 'a sample value');
+    const value = await service.getServiceConfig({address: 'config_path/key'});
+    assert.equal(value.value, 'a sample value');
   });
 
   t.test('should use process.env to get config when `useLocalEnvVars` is true', async (assert) => {
@@ -262,9 +261,9 @@ test('serviceConfig', (t) => {
       }
     });
 
-    const value = await service.getServiceConfig('serviceConfig:config_path/key');
+    const value = await service.getServiceConfig({address: 'config_path/key'});
 
-    assert.equal(value, 'an env var value');
+    assert.equal(value.value, 'an env var value');
   });
 });
 
@@ -297,7 +296,7 @@ test('secretConfig', (t) => {
     };
 
     const service = new ServerlessServiceConfig(slsConfig);
-    await service.getSecretConfig('secretConfig:vault/my_secret/secret, "fallback"');
+    await service.getSecretConfig({address: 'vault/my_secret/secret, "fallback"'});
     assert.true(
       vault2kmsStub.calledWith(
         'http://consul/v1/kv/vault/my_secret/secret',
@@ -345,16 +344,16 @@ test('secretConfig', (t) => {
         fakeKms,
         'kmsKeyId'
       )
-      .resolves('a base64 encrypted secret');
+      .resolves({'value': 'a base64 encrypted secret'});
 
     kmsConfigStub.reset();
     kmsConfigStub.withArgs(slsConfig).returns(fakeKms);
 
     const service = new ServerlessServiceConfig(slsConfig);
 
-    const value = await service.getSecretConfig('secretConfig:vault/my_secret/secret');
+    const value = await service.getSecretConfig({address: 'vault/my_secret/secret'});
 
-    assert.equal(value, 'a base64 encrypted secret');
+    assert.equal(value.value, 'a base64 encrypted secret');
   });
 
   t.test('should be able to get kms key id from consul', async (assert) => {
@@ -391,21 +390,21 @@ test('secretConfig', (t) => {
         fakeKms,
         'kmsKeyId'
       )
-      .resolves('a base64 encrypted secret');
+      .resolves({'value': 'a base64 encrypted secret'});
 
     kmsConfigStub.reset();
     kmsConfigStub.withArgs(slsConfig).returns(fakeKms);
 
     const getServiceConfigStub = sinon.stub();
-    getServiceConfigStub.withArgs('serviceConfig:path/to/key_id').returns('kmsKeyId');
+    getServiceConfigStub.withArgs({address: 'path/to/key_id'}).returns('kmsKeyId');
 
     const service = new ServerlessServiceConfig(slsConfig);
 
     service.getServiceConfig = getServiceConfigStub;
 
-    const value = await service.getSecretConfig('secretConfig:vault/my_secret/secret');
+    const value = await service.getSecretConfig({address: 'vault/my_secret/secret'});
 
-    assert.equal(value, 'a base64 encrypted secret');
+    assert.equal(value.value, 'a base64 encrypted secret');
   });
 
   t.test('should fail if kms key id definition is missing', async (assert) => {
@@ -429,7 +428,7 @@ test('secretConfig', (t) => {
     });
 
     try {
-      await service.getSecretConfig('secretConfig:vault/my_secret/secret');
+      await service.getSecretConfig({address: 'vault/my_secret/secret'});
     } catch (e) {
       assert.match(e.message, /^KMS Key Id missing/);
     }
@@ -460,7 +459,7 @@ test('secretConfig', (t) => {
     });
 
     try {
-      await service.getSecretConfig('secretConfig:vault/my_secret/secret');
+      await service.getSecretConfig({address: 'vault/my_secret/secret'});
     } catch (e) {
       assert.match(e.message, /^KMS Key Id missing/);
     }
@@ -515,9 +514,9 @@ test('secretConfig', (t) => {
 
       const service = new ServerlessServiceConfig(slsConfig);
 
-      const value = await service.getServiceConfig('secretConfig:config_path/key');
+      const value = await service.getServiceConfig({address: 'config_path/key'});
 
-      assert.equal(value, 'an env var value');
+      assert.equal(value.value, 'an env var value');
     }
   );
 });

--- a/src/kms_config.js
+++ b/src/kms_config.js
@@ -8,7 +8,7 @@ const load = (serverlessConfig = {}) => {
   if (service && service.provider && service.provider.region) {
     awsConfig.region = service.provider.region;
   }
-  
+
   return new aws.KMS(awsConfig);
 };
 

--- a/src/kms_config.js
+++ b/src/kms_config.js
@@ -3,18 +3,12 @@ const aws = require('aws-sdk');
 const load = (serverlessConfig = {}) => {
   const awsConfig = {};
 
-  const { service, variables } = serverlessConfig;
+  const { service } = serverlessConfig;
 
   if (service && service.provider && service.provider.region) {
     awsConfig.region = service.provider.region;
   }
-
-  const profile = variables.options['aws-profile'];
-
-  if (profile) {
-    awsConfig.credentials = new aws.SharedIniFileCredentials({ profile });
-  }
-
+  
   return new aws.KMS(awsConfig);
 };
 

--- a/src/kms_config.js
+++ b/src/kms_config.js
@@ -1,7 +1,6 @@
 const aws = require('aws-sdk');
 
 const load = (serverlessConfig = {}) => {
-  console.log(serverlessConfig)
   const awsConfig = {};
 
   const { service, variables } = serverlessConfig;

--- a/src/kms_config.js
+++ b/src/kms_config.js
@@ -1,6 +1,7 @@
 const aws = require('aws-sdk');
 
 const load = (serverlessConfig = {}) => {
+  console.log(serverlessConfig)
   const awsConfig = {};
 
   const { service, variables } = serverlessConfig;

--- a/src/utils/get-groups.js
+++ b/src/utils/get-groups.js
@@ -1,6 +1,6 @@
 module.exports = (param) => {
   // eslint-disable-next-line prefer-regex-literals
-  const regex = new RegExp('[serviceConfig|secretConfig]:([\\w\\/:\\.$\\{\\}\\-]+),?\\s?([\\"\\w]+)?');
+  const regex = new RegExp('([\\w\\/:\\.$\\{\\}\\-]+),?\\s?([\\"\\w]+)?');
   // eslint-disable-next-line no-unused-vars
   const [full, path, fallback = null] = param.match(regex);
   return {

--- a/src/utils/get-groups.test.js
+++ b/src/utils/get-groups.test.js
@@ -3,114 +3,114 @@ const test = require('tape');
 
 const target = require('./get-groups');
 
-test('${secretConfig:${self:custom.serviceConfigPath}/secrets/FACT_FIND_API_KEY}', async (assert) => {
+test('green/secrets/FACT_FIND_API_KEY}', async (assert) => {
   assert.plan(1);
 
-  const input = 'secretConfig:${self:custom.serviceConfigPath}/secrets/FACT_FIND_API_KEY';
+  const input = 'green/secrets/FACT_FIND_API_KEY';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/secrets/FACT_FIND_API_KEY',
+    path: 'green/secrets/FACT_FIND_API_KEY',
     fallback: null
   });
 });
 
-test('${secretConfig:${self:custom.serviceConfigPath}/secrets/FACT_FIND_API_KEY, foo}', async (assert) => {
+test('green/secrets/FACT_FIND_API_KEY, foo}', async (assert) => {
   assert.plan(1);
 
-  const input = 'secretConfig:${self:custom.serviceConfigPath}/secrets/FACT_FIND_API_KEY, foo';
+  const input = 'green/secrets/FACT_FIND_API_KEY, foo';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/secrets/FACT_FIND_API_KEY',
+    path: 'green/secrets/FACT_FIND_API_KEY',
     fallback: 'foo'
   });
 });
 
-test('${secretConfig:${self:custom.serviceConfigPath}/secrets/REPORT_GENERATOR_API_KEY}', async (assert) => {
+test('green/secrets/REPORT_GENERATOR_API_KEY}', async (assert) => {
   assert.plan(1);
 
-  const input = 'secretConfig:${self:custom.serviceConfigPath}/secrets/REPORT_GENERATOR_API_KEY';
+  const input = 'green/secrets/REPORT_GENERATOR_API_KEY';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/secrets/REPORT_GENERATOR_API_KEY',
+    path: 'green/secrets/REPORT_GENERATOR_API_KEY',
     fallback: null
   });
 });
 
-test('${secretConfig:${self:custom.serviceConfigPath}/secrets/REPORT_GENERATOR_API_KEY, foo}', async (assert) => {
+test('green/secrets/REPORT_GENERATOR_API_KEY, foo}', async (assert) => {
   assert.plan(1);
 
-  const input = 'secretConfig:${self:custom.serviceConfigPath}/secrets/REPORT_GENERATOR_API_KEY, foo';
+  const input = 'green/secrets/REPORT_GENERATOR_API_KEY, foo';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/secrets/REPORT_GENERATOR_API_KEY',
+    path: 'green/secrets/REPORT_GENERATOR_API_KEY',
     fallback: 'foo'
   });
 });
 
-test('${serviceConfig:${self:custom.serviceConfigPath}/ConfigMap/COMMON_NAMESPACE_BASE_URL}', async (assert) => {
+test('green/ConfigMap/COMMON_NAMESPACE_BASE_URL}', async (assert) => {
   assert.plan(1);
 
-  const input = 'serviceConfig:${self:custom.serviceConfigPath}/ConfigMap/COMMON_NAMESPACE_BASE_URL';
+  const input = 'green/ConfigMap/COMMON_NAMESPACE_BASE_URL';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/ConfigMap/COMMON_NAMESPACE_BASE_URL',
+    path: 'green/ConfigMap/COMMON_NAMESPACE_BASE_URL',
     fallback: null
   });
 });
 
-test('${serviceConfig:${self:custom.serviceConfigPath}/ConfigMap/COMMON_NAMESPACE_BASE_URL, foo}', async (assert) => {
+test('green/ConfigMap/COMMON_NAMESPACE_BASE_URL, foo}', async (assert) => {
   assert.plan(1);
 
-  const input = 'serviceConfig:${self:custom.serviceConfigPath}/ConfigMap/COMMON_NAMESPACE_BASE_URL, foo';
+  const input = 'green/ConfigMap/COMMON_NAMESPACE_BASE_URL, foo';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/ConfigMap/COMMON_NAMESPACE_BASE_URL',
+    path: 'green/ConfigMap/COMMON_NAMESPACE_BASE_URL',
     fallback: 'foo'
   });
 });
 
-test('${serviceConfig:${self:custom.serviceConfigPath}/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST}', async (assert) => {
+test('green{self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST}', async (assert) => {
   assert.plan(1);
 
-  const input = 'serviceConfig:${self:custom.serviceConfigPath}/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST';
+  const input = 'green/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST',
+    path: 'green/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST',
     fallback: null
   });
 });
 
-test('${serviceConfig:${self:custom.serviceConfigPath}/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST, oui}', async (assert) => {
+test('green{self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST, oui}', async (assert) => {
   assert.plan(1);
 
-  const input = 'serviceConfig:${self:custom.serviceConfigPath}/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST, oui';
+  const input = 'green/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST, oui';
 
   const result = target(input);
 
   assert.deepEqual(result, {
-    path: '${self:custom.serviceConfigPath}/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST',
+    path: 'green/${self:provider.stage}/ConfigMap/PIERRE_IS_THE_BEST',
     fallback: 'oui'
   });
 });
 
-test('${serviceConfig:global/config.json/IP-aliases/OFFICES}', async (assert) => {
+test('global/OFFICES}', async (assert) => {
   assert.plan(1);
 
-  const input = 'serviceConfig:global/config.json/IP-aliases/OFFICES';
+  const input = 'global/config.json/IP-aliases/OFFICES';
 
   const result = target(input);
 

--- a/src/vault2kms.js
+++ b/src/vault2kms.js
@@ -44,8 +44,7 @@ const retrieveAndEncrypt = async (path, vaultPrefix, kms, kmsKeyId, fallback = n
       'Missing vault token for authentication, you need to set VAULT_TOKEN as a environment variable'
     );
   }
-  const secretPath = await consul.get(path, fallback);
-  const secretValue = await getSecretFromVault(secretPath, vaultPrefix, fallback);
+  const secretValue = await getSecretFromVault(path, vaultPrefix, fallback);
   return kmsEncrypt(
     {
       KeyId: kmsKeyId,

--- a/src/vault2kms.js
+++ b/src/vault2kms.js
@@ -30,7 +30,9 @@ const kmsEncrypt = async (params, kms) => {
   const data = await kms.encrypt(params).promise();
 
   if (data && data.CiphertextBlob) {
-    return data.CiphertextBlob.toString('base64');
+    return {
+      value: data.CiphertextBlob.toString('base64')
+    };
   }
 
   throw new Error('Missing encrypted secret value from AWS response');

--- a/src/vault2kms.js
+++ b/src/vault2kms.js
@@ -1,5 +1,4 @@
 const request = require('request-promise-native');
-const consul = require('./consul');
 
 const getSecretFromVault = async (secretPath, vaultPrefix, fallback) => {
   try {

--- a/src/vault2kms.test.js
+++ b/src/vault2kms.test.js
@@ -19,14 +19,11 @@ test('before - fake vault token', (t) => {
   t.end();
 });
 
-test('should retrieve secret path from Consul, secret from Vault and encrypt with KMS', async (assert) => {
+test('should retrieve secret from Vault and encrypt with KMS', async (assert) => {
   assert.plan(1);
 
-  consulStub.reset();
   requestStub.reset();
   kmsStub.reset();
-
-  consulStub.withArgs('path/to/secret').resolves('secret/path');
 
   requestStub
     .withArgs({
@@ -57,7 +54,7 @@ test('should retrieve secret path from Consul, secret from Vault and encrypt wit
     });
 
   const encryptedSecret = await vault2kms.retrieveAndEncrypt(
-    'path/to/secret',
+    'secret/path',
     'http://vault/',
     kms,
     'kmsKeyId'
@@ -67,9 +64,6 @@ test('should retrieve secret path from Consul, secret from Vault and encrypt wit
 });
 
 test('should throw if no data is returned from Vault', async (assert) => {
-  consulStub.reset();
-
-  consulStub.withArgs('path/to/secret').resolves('secret/path');
 
   const expectedVaultResponses = [{ data: {} }, {}, null];
 
@@ -80,7 +74,7 @@ test('should throw if no data is returned from Vault', async (assert) => {
     requestStub.resolves(response);
 
     try {
-      await vault2kms.retrieveAndEncrypt('path/to/secret', 'http://vault/', kms, 'kmsKeyId');
+      await vault2kms.retrieveAndEncrypt('secret/path', 'http://vault/', kms, 'kmsKeyId');
     } catch (e) {
       assert.equal(e.message, 'Missing secret in Vault at secret/path');
     }
@@ -88,10 +82,6 @@ test('should throw if no data is returned from Vault', async (assert) => {
 });
 
 test('should throw friendler exception when Vault returns 404', async (assert) => {
-  consulStub.reset();
-
-  consulStub.withArgs('path/to/secret').resolves('secret/path');
-
   const notFoundError = new Error('404 - not found');
   notFoundError.statusCode = 404;
 
@@ -101,7 +91,7 @@ test('should throw friendler exception when Vault returns 404', async (assert) =
   requestStub.rejects(notFoundError);
 
   try {
-    await vault2kms.retrieveAndEncrypt('path/to/secret', 'http://vault/', kms, 'kmsKeyId');
+    await vault2kms.retrieveAndEncrypt('secret/path', 'http://vault/', kms, 'kmsKeyId');
   } catch (e) {
     assert.equal(e.message, 'Missing secret in Vault at secret/path');
   }

--- a/src/vault2kms.test.js
+++ b/src/vault2kms.test.js
@@ -64,7 +64,6 @@ test('should retrieve secret from Vault and encrypt with KMS', async (assert) =>
 });
 
 test('should throw if no data is returned from Vault', async (assert) => {
-
   const expectedVaultResponses = [{ data: {} }, {}, null];
 
   assert.plan(expectedVaultResponses.length);

--- a/src/vault2kms.test.js
+++ b/src/vault2kms.test.js
@@ -63,7 +63,7 @@ test('should retrieve secret path from Consul, secret from Vault and encrypt wit
     'kmsKeyId'
   );
 
-  assert.equal(encryptedSecret, 'ZW5jcnlwdGVkOmZha2Vfc2VjcmV0');
+  assert.equal(encryptedSecret.value, 'ZW5jcnlwdGVkOmZha2Vfc2VjcmV0');
 });
 
 test('should throw if no data is returned from Vault', async (assert) => {
@@ -170,7 +170,7 @@ test('should return fallback if defined and key not present', async (assert) => 
     'fallback'
   );
 
-  assert.equal(encryptedSecret, 'ZW5jcnlwdGVkOmZhbGxiYWNr');
+  assert.equal(encryptedSecret.value, 'ZW5jcnlwdGVkOmZhbGxiYWNr');
 });
 
 test('after - unset fake vault token', (t) => {


### PR DESCRIPTION
Made necessary breaking changes in order for the plugin to work with serverless v3. The main issue this introduced was disallowing our use of custom CLI arguments. These will need to be replaced by use of params project by project, have written notes in the README on how to migrate existing projects using this plugin.

As part of the breaking upgrade, have also simplified interaction with the plugin:
- Rename serviceConfig -> consul, secretConfig-> vault
- vault provided with a vault path directly, not a consul kv item containing a vault path