### PR TITLE
chore: :bug: correctly check axios response status for 404

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "serverless-service-config-plugin",
-  "version": "1.0.5",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-service-config-plugin",
-      "version": "1.0.5",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.259.0",
-        "axios": "^1.4.0"
+        "axios": "^1.7.2"
       },
       "devDependencies": {
         "escope": "^3.6.0",
@@ -1614,9 +1614,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -5541,9 +5541,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-kms": "^3.259.0",
-    "axios": "^1.4.0"
+    "axios": "^1.7.2"
   },
   "devDependencies": {
     "escope": "^3.6.0",

--- a/src/consul.js
+++ b/src/consul.js
@@ -39,7 +39,7 @@ async function get(url, fallback = null) {
       };
     }
   } catch (e) {
-    if (e.statusCode !== 404) {
+    if (e.response?.status !== 404) {
       throw e;
     }
   }

--- a/src/consul.test.js
+++ b/src/consul.test.js
@@ -53,7 +53,7 @@ test('should display friendlier error when receiving 404 from Consul', async (as
   assert.plan(1);
 
   const notFoundError = new Error();
-  notFoundError.statusCode = 404;
+  notFoundError.response = { status: 404 };
 
   axiosStub.reset();
   axiosStub.rejects(notFoundError);


### PR DESCRIPTION
It should not throw when 404 is returned from consul request, the current code checks the status and throws if it's not 404. The problem is statusCode does not exist on the axios error, we should be checking `error.response.status` instead.

This bug means that the fallback functionality for when a value is not found doesn't work and causes the pipeline to fail.